### PR TITLE
Fixed deprecated 'each' function which was giving warning on php 7.2

### DIFF
--- a/application/third_party/MX/Modules.php
+++ b/application/third_party/MX/Modules.php
@@ -80,7 +80,7 @@ class Modules
 	/** Load a module controller **/
 	public static function load($module) 
 	{
-		(is_array($module)) ? list($module, $params) = each($module) : $params = NULL;	
+		(is_array($module)) ? list($module, $params) = [key($module), current($module)] : $params = NULL;	
 		
 		/* get the requested controller class name */
 		$alias = strtolower(basename($module));


### PR DESCRIPTION
![ShamsPathan](https://user-images.githubusercontent.com/32018586/85956101-39e0d600-b9a5-11ea-83ee-0412c8d86988.PNG)
### Fixed this